### PR TITLE
Read and write structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/jgarzik/gdbm-native-rs.git"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-byteorder = "^1.3"
 base64 = "^0.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -98,7 +98,7 @@ impl Bucket {
     pub fn from_reader(header: &Header, rdr: &mut impl Read) -> io::Result<Self> {
         // read avail section
         let av_count;
-        if header.endian == Endian::Little {
+        if header.endian() == Endian::Little {
             av_count = rdr.read_u32::<LittleEndian>()?;
             let _padding = rdr.read_u32::<LittleEndian>()?;
         } else {
@@ -109,14 +109,14 @@ impl Bucket {
         // read av_count entries from bucket_avail[]
         let mut avail = Vec::new();
         for _idx in 0..av_count {
-            let av_elem = AvailElem::from_reader(header.alignment, header.endian, rdr)?;
+            let av_elem = AvailElem::from_reader(header.alignment(), header.endian(), rdr)?;
             avail.push(av_elem);
         }
 
         // read remaining to-be-ignored entries from bucket_avail[]
         let pad_elems = BUCKET_AVAIL - avail.len();
         for _idx in 0..pad_elems {
-            let _av_elem = AvailElem::from_reader(header.alignment, header.endian, rdr)?;
+            let _av_elem = AvailElem::from_reader(header.alignment(), header.endian(), rdr)?;
         }
 
         // todo: validate and assure-sorted avail[]
@@ -124,7 +124,7 @@ impl Bucket {
         // read misc. section
         let (bits, count);
 
-        if header.endian == Endian::Little {
+        if header.endian() == Endian::Little {
             bits = rdr.read_u32::<LittleEndian>()?;
             count = rdr.read_u32::<LittleEndian>()?;
         } else {
@@ -139,7 +139,7 @@ impl Bucket {
         // read bucket elements section
         let mut tab = Vec::new();
         for _idx in 0..header.bucket_elems {
-            let bucket_elem = BucketElement::from_reader(header.alignment, header.endian, rdr)?;
+            let bucket_elem = BucketElement::from_reader(header.alignment(), header.endian(), rdr)?;
             tab.push(bucket_elem);
         }
 

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -75,7 +75,7 @@ fn roff_t(f: &mut std::fs::File, alignment: Alignment, endian: Endian) -> io::Re
 
 // Read C-struct-based bucket directory (a vector of storage offsets)
 pub fn dir_reader(f: &mut std::fs::File, header: &Header) -> io::Result<Vec<u64>> {
-    let dirent_count = header.dir_sz as usize / dirent_elem_size(header.alignment);
+    let dirent_count = header.dir_sz as usize / dirent_elem_size(header.alignment());
 
     let mut dir = Vec::new();
     dir.reserve_exact(dirent_count);
@@ -83,7 +83,7 @@ pub fn dir_reader(f: &mut std::fs::File, header: &Header) -> io::Result<Vec<u64>
     let _pos = f.seek(SeekFrom::Start(header.dir_ofs))?;
 
     for _idx in 0..dirent_count {
-        let ofs = roff_t(f, header.alignment, header.endian)?;
+        let ofs = roff_t(f, header.alignment(), header.endian())?;
         dir.push(ofs);
     }
 

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -8,10 +8,9 @@
 // file in the root directory of this project.
 // SPDX-License-Identifier: MIT
 
-use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
 use std::io::{self, Seek, SeekFrom};
 
-use crate::ser::{woff_t, Alignment, Endian};
+use crate::ser::{read32, read64, woff_t, Alignment, Endian};
 use crate::{Header, GDBM_HASH_BITS};
 
 pub fn build_dir_size(block_sz: u32) -> (u32, u32) {
@@ -55,37 +54,13 @@ pub fn dirent_elem_size(alignment: Alignment) -> usize {
     }
 }
 
-fn roff_t(f: &mut std::fs::File, alignment: Alignment, endian: Endian) -> io::Result<u64> {
-    let v;
-
-    if endian == Endian::Little {
-        if alignment == Alignment::Align64 {
-            v = f.read_u64::<LittleEndian>()?;
-        } else {
-            v = f.read_u32::<LittleEndian>()? as u64;
-        }
-    } else if alignment == Alignment::Align64 {
-        v = f.read_u64::<BigEndian>()?;
-    } else {
-        v = f.read_u32::<BigEndian>()? as u64;
-    }
-
-    Ok(v)
-}
-
 // Read C-struct-based bucket directory (a vector of storage offsets)
 pub fn dir_reader(f: &mut std::fs::File, header: &Header) -> io::Result<Vec<u64>> {
-    let dirent_count = header.dir_sz as usize / dirent_elem_size(header.alignment());
-
-    let mut dir = Vec::new();
-    dir.reserve_exact(dirent_count);
-
-    let _pos = f.seek(SeekFrom::Start(header.dir_ofs))?;
-
-    for _idx in 0..dirent_count {
-        let ofs = roff_t(f, header.alignment(), header.endian())?;
-        dir.push(ofs);
-    }
-
-    Ok(dir)
+    f.seek(SeekFrom::Start(header.dir_ofs))?;
+    (0..header.dir_sz as usize / dirent_elem_size(header.alignment()))
+        .map(|_| match header.alignment() {
+            Alignment::Align32 => read32(header.endian(), f).map(|v| v as u64),
+            Alignment::Align64 => read64(header.endian(), f),
+        })
+        .collect::<io::Result<Vec<_>>>()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ impl Gdbm {
         let metadata = f.metadata()?;
 
         // read gdbm global header
-        let header = Header::from_reader(&metadata, f.try_clone()?)?;
+        let header = Header::from_reader(&metadata, &mut f)?;
         println!("{:?}", header);
 
         // read gdbm hash directory

--- a/src/magic.rs
+++ b/src/magic.rs
@@ -1,0 +1,76 @@
+use std::fmt;
+use std::io::{Error, ErrorKind, Result};
+
+use crate::ser::{Alignment, Endian};
+
+const GDBM_OMAGIC_LE: [u8; 4] = [0xce, 0x9a, 0x57, 0x13];
+const GDBM_OMAGIC_BE: [u8; 4] = [0x13, 0x57, 0x9a, 0xce];
+const GDBM_MAGIC_LE_32: [u8; 4] = [0xcd, 0x9a, 0x57, 0x13];
+const GDBM_MAGIC_LE_64: [u8; 4] = [0xcf, 0x9a, 0x57, 0x13];
+const GDBM_MAGIC_BE_32: [u8; 4] = [0x13, 0x57, 0x9a, 0xcd];
+const GDBM_MAGIC_BE_64: [u8; 4] = [0x13, 0x57, 0x9a, 0xcf];
+
+#[derive(Debug)]
+pub enum Magic {
+    LE,
+    BE,
+    LE32,
+    BE32,
+    LE64,
+    BE64,
+}
+
+impl Magic {
+    pub fn from_reader(rdr: &mut impl std::io::Read) -> Result<Self> {
+        let mut buf = [0u8; 4];
+        rdr.read_exact(&mut buf)?;
+        match buf {
+            GDBM_OMAGIC_LE => Ok(Magic::LE),
+            GDBM_OMAGIC_BE => Ok(Magic::BE),
+            GDBM_MAGIC_LE_32 => Ok(Magic::LE32),
+            GDBM_MAGIC_BE_32 => Ok(Magic::BE32),
+            GDBM_MAGIC_LE_64 => Ok(Magic::LE64),
+            GDBM_MAGIC_BE_64 => Ok(Magic::BE64),
+            _ => Err(Error::new(ErrorKind::Other, "Unknown/invalid magic number")),
+        }
+    }
+
+    pub fn endian(&self) -> Endian {
+        match self {
+            Magic::LE | Magic::LE32 | Magic::LE64 => Endian::Little,
+            _ => Endian::Big,
+        }
+    }
+
+    pub fn alignment(&self) -> Alignment {
+        match self {
+            Magic::LE64 | Magic::BE64 => Alignment::Align64,
+            _ => Alignment::Align32,
+        }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            Magic::LE => &GDBM_OMAGIC_LE,
+            Magic::LE32 => &GDBM_MAGIC_LE_32,
+            Magic::LE64 => &GDBM_MAGIC_LE_64,
+            Magic::BE => &GDBM_OMAGIC_BE,
+            Magic::BE32 => &GDBM_MAGIC_BE_32,
+            Magic::BE64 => &GDBM_MAGIC_BE_64,
+        }
+    }
+}
+
+impl fmt::Display for Magic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Magic::LE => "GDBM_OMAGIC",
+            Magic::LE32 => "GDBM_MAGIC32",
+            Magic::LE64 => "GDBM_MAGIC64",
+            Magic::BE => "GDBM_OMAGIC_SWAP",
+            Magic::BE32 => "GDBM_MAGIC32_SWAP",
+            Magic::BE64 => "GDBM_MAGIC64_SWAP",
+        };
+        write!(f, "{}", name)
+    }
+}

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -8,7 +8,7 @@
 // file in the root directory of this project.
 // SPDX-License-Identifier: MIT
 
-use std::io::{self, Read};
+use std::io::{self, Read, Write};
 
 /// Field alignment of DB file
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -50,27 +50,18 @@ pub fn read64(endian: Endian, reader: &mut impl Read) -> io::Result<u64> {
     })
 }
 
-// serialize u32, with runtime endian selection
-pub fn w32(endian: Endian, val: u32) -> Vec<u8> {
-    match endian {
-        Endian::Little => val.to_le_bytes(),
-        Endian::Big => val.to_be_bytes(),
-    }
-    .to_vec()
+pub fn write32(endian: Endian, writer: &mut impl Write, value: u32) -> io::Result<()> {
+    let bytes = match endian {
+        Endian::Little => value.to_le_bytes(),
+        Endian::Big => value.to_be_bytes(),
+    };
+    writer.write_all(&bytes)
 }
 
-// serialize u64, with runtime endian selection
-pub fn w64(endian: Endian, val: u64) -> Vec<u8> {
-    match endian {
-        Endian::Little => val.to_le_bytes(),
-        Endian::Big => val.to_be_bytes(),
-    }
-    .to_vec()
-}
-
-pub fn woff_t(alignment: Alignment, endian: Endian, val: u64) -> Vec<u8> {
-    match alignment {
-        Alignment::Align32 => w32(endian, val as u32),
-        Alignment::Align64 => w64(endian, val),
-    }
+pub fn write64(endian: Endian, writer: &mut impl Write, value: u64) -> io::Result<()> {
+    let bytes = match endian {
+        Endian::Little => value.to_le_bytes(),
+        Endian::Big => value.to_be_bytes(),
+    };
+    writer.write_all(&bytes)
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -8,35 +8,43 @@
 // file in the root directory of this project.
 // SPDX-License-Identifier: MIT
 
-use byteorder::{BigEndian, ByteOrder, LittleEndian};
+/// Field alignment of DB file
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Alignment {
+    /// File offset fields are 32bit
+    Align32,
+    /// File offset fields are 64bit
+    Align64,
+}
+
+/// Endianness of DB file
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Endian {
+    Little,
+    Big,
+}
 
 // serialize u32, with runtime endian selection
-pub fn w32(is_le: bool, val: u32) -> Vec<u8> {
-    let mut buf = vec![0; 4];
-
-    match is_le {
-        true => LittleEndian::write_u32(&mut buf, val),
-        false => BigEndian::write_u32(&mut buf, val),
+pub fn w32(endian: Endian, val: u32) -> Vec<u8> {
+    match endian {
+        Endian::Little => val.to_le_bytes(),
+        Endian::Big => val.to_be_bytes(),
     }
-
-    buf
+    .to_vec()
 }
 
 // serialize u64, with runtime endian selection
-pub fn w64(is_le: bool, val: u64) -> Vec<u8> {
-    let mut buf = vec![0; 8];
-
-    match is_le {
-        true => LittleEndian::write_u64(&mut buf, val),
-        false => BigEndian::write_u64(&mut buf, val),
+pub fn w64(endian: Endian, val: u64) -> Vec<u8> {
+    match endian {
+        Endian::Little => val.to_le_bytes(),
+        Endian::Big => val.to_be_bytes(),
     }
-
-    buf
+    .to_vec()
 }
 
-pub fn woff_t(is_lfs: bool, is_le: bool, val: u64) -> Vec<u8> {
-    match is_lfs {
-        true => w64(is_le, val),
-        false => w32(is_le, val as u32),
+pub fn woff_t(alignment: Alignment, endian: Endian, val: u64) -> Vec<u8> {
+    match alignment {
+        Alignment::Align32 => w32(endian, val as u32),
+        Alignment::Align64 => w64(endian, val),
     }
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -8,6 +8,8 @@
 // file in the root directory of this project.
 // SPDX-License-Identifier: MIT
 
+use std::io::{self, Read};
+
 /// Field alignment of DB file
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Alignment {
@@ -17,11 +19,35 @@ pub enum Alignment {
     Align64,
 }
 
+impl Alignment {
+    pub fn is64(&self) -> bool {
+        *self == Alignment::Align64
+    }
+}
+
 /// Endianness of DB file
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Endian {
     Little,
     Big,
+}
+
+pub fn read32(endian: Endian, reader: &mut impl Read) -> io::Result<u32> {
+    let mut bytes = [0u8; 4];
+    reader.read_exact(&mut bytes)?;
+    Ok(match endian {
+        Endian::Little => u32::from_le_bytes(bytes),
+        Endian::Big => u32::from_be_bytes(bytes),
+    })
+}
+
+pub fn read64(endian: Endian, reader: &mut impl Read) -> io::Result<u64> {
+    let mut bytes = [0u8; 8];
+    reader.read_exact(&mut bytes)?;
+    Ok(match endian {
+        Endian::Little => u64::from_le_bytes(bytes),
+        Endian::Big => u64::from_be_bytes(bytes),
+    })
 }
 
 // serialize u32, with runtime endian selection


### PR DESCRIPTION
~This series of commits moves all database read and write operations into DBReader and DBWriter instance methods (see ser.rs).~

Move all database struct reads and writes into ser.rs. Replace existing read and write functions with `read32`, `read64`, `write32` and `write64`, all of which take an endianness parameter, and a `Read` or `Write` implementation. 