### PR TITLE
bugfix: works for all DB alignment and off_t

### DIFF
--- a/src/magic.rs
+++ b/src/magic.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::io::{Error, ErrorKind, Result};
 
-use crate::ser::{Alignment, Endian};
+use crate::ser::{Alignment, Endian, Offset};
 
 const GDBM_OMAGIC_LE: [u8; 4] = [0xce, 0x9a, 0x57, 0x13];
 const GDBM_OMAGIC_BE: [u8; 4] = [0x13, 0x57, 0x9a, 0xce];
@@ -42,9 +42,16 @@ impl Magic {
         }
     }
 
-    pub fn alignment(&self) -> Alignment {
+    pub fn offset(&self) -> Offset {
         match self {
-            Magic::LE64 | Magic::BE64 => Alignment::Align64,
+            Magic::LE64 | Magic::BE64 => Offset::LFS,
+            _ => Offset::Small,
+        }
+    }
+
+    pub fn default_alignment(&self) -> Alignment {
+        match self {
+            Magic::BE64 | Magic::LE64 => Alignment::Align64,
             _ => Alignment::Align32,
         }
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -10,12 +10,14 @@
 
 use std::io::{self, Read, Write};
 
-/// Field alignment of DB file
+/// Struct field alignment of DB file
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Alignment {
-    /// File offset fields are 32bit
+    /// All fields aligned on 4byte boundaries.
+    /// Struct sizes are multiple of 4.
     Align32,
-    /// File offset fields are 64bit
+    /// Fields larger than 4byte aligned on 8byte boundaries.
+    /// Struct sizes are multiple of 8.
     Align64,
 }
 
@@ -30,6 +32,23 @@ impl Alignment {
 pub enum Endian {
     Little,
     Big,
+}
+
+/// Offset types: LFS (64bit) or Small (32bit)
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Offset {
+    // Offset fields are 32bit.
+    Small,
+    // Offset fields are 64bit.
+    LFS,
+}
+
+/// Container for layout possibilities.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Layout {
+    pub alignment: Alignment,
+    pub endian: Endian,
+    pub offset: Offset,
 }
 
 pub fn read32(endian: Endian, reader: &mut impl Read) -> io::Result<u32> {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,6 @@
 extern crate gdbm_native;
 
+use gdbm_native::ser::Alignment;
 use gdbm_native::GdbmOptions;
 use serde::Deserialize;
 use std::fs;
@@ -22,61 +23,70 @@ pub struct TestInfo {
     pub n_records: usize,
     #[allow(dead_code)]
     pub metadata: TestMetadata,
+    pub alignment: Option<Alignment>,
 }
 
-pub struct TestConfig {
-    pub def_ro_cfg: GdbmOptions,
-    pub def_rw_cfg: GdbmOptions,
-    pub tests: Vec<TestInfo>,
-}
+impl TestInfo {
+    fn new(db_fn: &str, json_fn: &str, is_basic: bool, alignment: Option<Alignment>) -> Self {
+        let mut dbp = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        dbp.push("src/data");
+        dbp.push(db_fn);
 
-impl TestConfig {
-    fn new() -> TestConfig {
-        TestConfig {
-            def_ro_cfg: GdbmOptions {
-                readonly: true,
-                creat: false,
-            },
-            def_rw_cfg: GdbmOptions {
-                readonly: false,
-                creat: false,
-            },
-            tests: Vec::new(),
+        let mut jsp = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        jsp.push("src/data");
+        jsp.push(json_fn);
+
+        let json_path = jsp.to_str().unwrap().to_string();
+        let json_data = fs::read_to_string(&json_path).expect("Unable to read JSON file");
+        let metadata: TestMetadata =
+            serde_json::from_str(&json_data).expect("Test JSON was not well formed");
+
+        Self {
+            db_path: dbp.to_str().unwrap().to_string(),
+            json_path,
+            is_basic,
+            n_records: metadata.data_records,
+            metadata,
+            alignment,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn ro_cfg(&self) -> GdbmOptions {
+        GdbmOptions {
+            readonly: true,
+            creat: false,
+            alignment: self.alignment,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn rw_cfg(&self) -> GdbmOptions {
+        GdbmOptions {
+            readonly: false,
+            creat: false,
+            alignment: self.alignment,
         }
     }
 }
 
-fn push_test(cfg: &mut TestConfig, db_fn: &str, json_fn: &str, is_basic: bool) {
-    let mut dbp = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    dbp.push("src/data");
-    dbp.push(db_fn);
-
-    let mut jsp = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    jsp.push("src/data");
-    jsp.push(json_fn);
-
-    let json_path = jsp.to_str().unwrap().to_string();
-    let json_data = fs::read_to_string(&json_path).expect("Unable to read JSON file");
-    let metadata: TestMetadata =
-        serde_json::from_str(&json_data).expect("Test JSON was not well formed");
-
-    cfg.tests.push(TestInfo {
-        db_path: dbp.to_str().unwrap().to_string(),
-        json_path,
-        is_basic,
-        n_records: metadata.data_records,
-        metadata,
-    });
-}
-
-pub fn init_tests() -> TestConfig {
-    let mut cfg = TestConfig::new();
-
-    // NOTE: Order of push is important.
-    // Some tests depend on basic.db being index 1 (2nd item)
-
-    push_test(&mut cfg, "empty.db.le64", "empty.json.le64", false);
-    push_test(&mut cfg, "basic.db.le64", "basic.json.le64", true);
-
-    cfg
+pub fn init_tests() -> Vec<TestInfo> {
+    [
+        ("le64", None),
+        ("be64", None),
+        ("le32", Some(Alignment::Align32)),
+        ("be32", None),
+    ]
+    .into_iter()
+    .flat_map(|(flavor, alignment)| {
+        ["empty", "basic"].into_iter().map(move |empty_or_basic| {
+            TestInfo::new(
+                &format!("{}.db.{}", empty_or_basic, flavor),
+                &format!("{}.json.{}", empty_or_basic, flavor),
+                empty_or_basic == "basic",
+                alignment,
+            )
+        })
+    })
+    .collect()
 }

--- a/tests/export.rs
+++ b/tests/export.rs
@@ -21,10 +21,10 @@ use gdbm_native::{ExportBinMode, Gdbm};
 fn api_export_bin() {
     const EXPORT_FN: &str = "./export.bin";
 
-    let testcfg = init_tests();
+    let tests = init_tests();
 
-    for testdb in &testcfg.tests {
-        let mut db = Gdbm::open(&testdb.db_path, &testcfg.def_ro_cfg).unwrap();
+    for testdb in tests {
+        let mut db = Gdbm::open(&testdb.db_path, &testdb.ro_cfg()).unwrap();
         let mut outf = OpenOptions::new()
             .read(true)
             .write(true)
@@ -45,10 +45,10 @@ fn api_export_bin() {
 fn api_export_ascii() {
     const EXPORT_FN: &str = "./export.txt";
 
-    let testcfg = init_tests();
+    let tests = init_tests();
 
-    for testdb in &testcfg.tests {
-        let mut db = Gdbm::open(&testdb.db_path, &testcfg.def_ro_cfg).unwrap();
+    for testdb in tests {
+        let mut db = Gdbm::open(&testdb.db_path, &testdb.ro_cfg()).unwrap();
         let mut outf = OpenOptions::new()
             .read(true)
             .write(true)

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -18,14 +18,13 @@ use std::collections::HashMap;
 
 #[test]
 fn api_exists_not() {
-    let testcfg = init_tests();
+    let tests = init_tests();
 
-    for testdb in &testcfg.tests {
-        let mut db = Gdbm::open(&testdb.db_path, &testcfg.def_ro_cfg).unwrap();
+    for testdb in tests {
+        let mut db = Gdbm::open(&testdb.db_path, &testdb.ro_cfg()).unwrap();
         assert!(!db.contains_key(b"dummy").unwrap());
 
         if testdb.is_basic {
-            db = Gdbm::open(&testdb.db_path, &testcfg.def_ro_cfg).unwrap();
             assert!(!db.contains_key(b"key -111").unwrap());
         }
     }
@@ -33,11 +32,11 @@ fn api_exists_not() {
 
 #[test]
 fn api_exists() {
-    let testcfg = init_tests();
+    let tests = init_tests();
 
-    for testdb in &testcfg.tests {
+    for testdb in tests {
         if testdb.is_basic {
-            let mut db = Gdbm::open(&testdb.db_path, &testcfg.def_ro_cfg).unwrap();
+            let mut db = Gdbm::open(&testdb.db_path, &testdb.ro_cfg()).unwrap();
 
             for n in 0..10001 {
                 let keystr = format!("key {}", n);
@@ -49,11 +48,11 @@ fn api_exists() {
 
 #[test]
 fn api_get_not() {
-    let testcfg = init_tests();
+    let tests = init_tests();
 
-    for testdb in &testcfg.tests {
+    for testdb in tests {
         let keystr = String::from("This key does not exist.");
-        let mut db = Gdbm::open(&testdb.db_path, &testcfg.def_ro_cfg).unwrap();
+        let mut db = Gdbm::open(&testdb.db_path, &testdb.ro_cfg()).unwrap();
         let res = db.get(keystr.as_bytes()).unwrap();
         assert_eq!(res, None);
     }
@@ -61,11 +60,11 @@ fn api_get_not() {
 
 #[test]
 fn api_get() {
-    let testcfg = init_tests();
+    let tests = init_tests();
 
-    for testdb in &testcfg.tests {
+    for testdb in tests {
         if testdb.is_basic {
-            let mut db = Gdbm::open(&testdb.db_path, &testcfg.def_ro_cfg).unwrap();
+            let mut db = Gdbm::open(&testdb.db_path, &testdb.ro_cfg()).unwrap();
 
             for n in 0..10001 {
                 let keystr = format!("key {}", n);
@@ -78,9 +77,9 @@ fn api_get() {
 
 #[test]
 fn api_first_next_key() {
-    let testcfg = init_tests();
+    let tests = init_tests();
 
-    for testdb in &testcfg.tests {
+    for testdb in tests {
         if testdb.is_basic {
             // build internal map of keys expected to be present in basic.db
             let mut keys_remaining: HashMap<Vec<u8>, bool> = HashMap::new();
@@ -93,7 +92,7 @@ fn api_first_next_key() {
             assert_eq!(keys_remaining.len(), testdb.n_records);
 
             // open basic.db
-            let mut db = Gdbm::open(&testdb.db_path, &testcfg.def_ro_cfg).unwrap();
+            let mut db = Gdbm::open(&testdb.db_path, &testdb.ro_cfg()).unwrap();
 
             // iterate through each key in db
             let mut key_res = db.first_key().unwrap();
@@ -114,20 +113,20 @@ fn api_first_next_key() {
 
 #[test]
 fn api_open_close() {
-    let testcfg = init_tests();
+    let tests = init_tests();
 
-    for testdb in &testcfg.tests {
-        let _res = Gdbm::open(&testdb.db_path, &testcfg.def_ro_cfg).unwrap();
+    for testdb in tests {
+        let _res = Gdbm::open(&testdb.db_path, &testdb.ro_cfg()).unwrap();
         // implicit close when scope closes
     }
 }
 
 #[test]
 fn api_len() {
-    let testcfg = init_tests();
+    let tests = init_tests();
 
-    for testdb in &testcfg.tests {
-        let mut db = Gdbm::open(&testdb.db_path, &testcfg.def_ro_cfg).unwrap();
+    for testdb in tests {
+        let mut db = Gdbm::open(&testdb.db_path, &testdb.ro_cfg()).unwrap();
         let res = db.len().unwrap();
         assert_eq!(res, testdb.n_records);
     }


### PR DESCRIPTION
off_t sizes can be determined from magic. Alignment, however cannot be determined from the DB file itself. The be32 DBs in the test data, created on mips, have 8 byte alignment, whereas the le32, created using debian i386 libgdbm have 4 byte alignment.

This PR adds an optional alignment value in GdbmOptions, to override the default alignment when the DB is opened. This alignment value is propagated through to the serialization functions.

Default alignment is 8 bytes for LFS DBs, otherwise 4 bytes.